### PR TITLE
Fixed Issue#200

### DIFF
--- a/client/app/main/main.html
+++ b/client/app/main/main.html
@@ -23,7 +23,7 @@
 	</a></li><li>Friday(4-5:15)  Meeting in DCC 318 
 	</li></ul></br>	
 	Our members work on a variety of projects, as can be seen
-	 <a href="http://rcos.rpi.edu/projects/">here</a>. 
+	 <a href="http://rcos.io/projects">here</a>. 
 	 The projects page is itself our dashboard to help us keep up with 
 	 the status of the projects!</a></p>
 		</p>

--- a/server/api/project/project.spec.js
+++ b/server/api/project/project.spec.js
@@ -18,3 +18,18 @@ describe('GET /api/projects', function() {
       });
   });
 });
+
+describe('GET /api/projects/past', function() {
+
+  it('should respond with JSON array', function(done) {
+    request(app)
+      .get('/api/projects/past')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end(function(err, res) {
+        if (err) return done(err);
+        res.body.should.be.instanceof(Array);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
We have fixed the issue addressed in issue #200.  We changed the link in the word 'here' of the description on the homepage where it says "Our members work on a variety of projects, as can be seen here."  Now the 'here' points to the new '/projects' projects page instead of the old 'rcos.rpi.edu'.