### PR TITLE
divide posts into semesters and a sidebar

### DIFF
--- a/client/app/projects/blog/blog.controller.js
+++ b/client/app/projects/blog/blog.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('observatory3App')
-.controller('ProjectsBlogCtrl', function ($scope, $http, $stateParams, $uibModal, Auth, Project, notify) {
+.controller('ProjectsBlogCtrl', function ($scope, $http, $stateParams, $uibModal, $anchorScroll, $location, Auth, Project, notify) {
     $scope.isAuthor = false;
     $scope.isLoggedIn = Auth.isLoggedIn;
     $scope.isAdmin = Auth.isAdmin;
@@ -80,12 +80,41 @@ angular.module('observatory3App')
         $scope.load();
     };
 
+    $scope.goto = function(id){
+      $location.hash(id);
+      if($location.hash()!==id){
+        $location.hash(id);
+      }
+      else{
+        $anchorScroll();
+      }
+    }
+
+    var sortPosts = function(){
+      $scope.semesters = {};
+      for(var i =$scope.posts.length-1; i >-1 ; --i){
+        var postDate = $scope.posts[i].date;
+        var year = postDate.substring(0,4);
+        var semester = '';
+        if(postDate.charAt(5) > 0 || postDate.charAt(6) > 7)
+          semester = 'Fall';
+        else
+          semester = 'Spring';
+        semester = semester + ' '+year;
+        if(!$scope.semesters.hasOwnProperty(semester)){
+          $scope.semesters[semester] = [];
+        }
+        $scope.semesters[semester].push($scope.posts[i]);
+      }
+    }
+
     $scope.load = function() {
       Project.getProject($stateParams.username, $stateParams.project).then(function(result){
           $scope.project = result.data;
 
           Project.getProjectPosts($scope.project._id).then(function(result){
               $scope.posts = result.data;
+              sortPosts();
           });
 
           if ($scope.isLoggedIn()){

--- a/client/app/projects/blog/blog.controller.js
+++ b/client/app/projects/blog/blog.controller.js
@@ -84,28 +84,40 @@ angular.module('observatory3App')
       $location.hash(id);
       if($location.hash()!==id){
         $location.hash(id);
-      }
-      else{
+      }else{
         $anchorScroll();
       }
     }
 
     var sortPosts = function(){
       $scope.semesters = {};
+      $scope.listOfsem = [];
       for(var i =$scope.posts.length-1; i >-1 ; --i){
         var postDate = $scope.posts[i].date;
         var year = postDate.substring(0,4);
         var semester = '';
-        if(postDate.charAt(5) > 0 || postDate.charAt(6) > 7)
+        if(postDate.charAt(5) > 0 || postDate.charAt(6) > 7){
           semester = 'Fall';
-        else
+        }else{
           semester = 'Spring';
+        }
         semester = semester + ' '+year;
         if(!$scope.semesters.hasOwnProperty(semester)){
           $scope.semesters[semester] = [];
         }
         $scope.semesters[semester].push($scope.posts[i]);
+        $scope.listOfsem.push(semester);
       }
+      $scope.listOfsem.sort(semesterComparator);
+    }
+
+    var semesterComparator = function(s1,s2){
+      var s1parts = s1.split(" ");
+      var s2parts = s2.split(" ");
+      if(s1parts[1] === s2parts[1]){
+        return s1parts[0] === "Spring" ? 1 : -1;
+      }
+      return s1parts[1] < s2parts[1] ? 1 : -1;
     }
 
     $scope.load = function() {

--- a/client/app/projects/blog/blog.html
+++ b/client/app/projects/blog/blog.html
@@ -13,7 +13,7 @@
   </div>
 
   <div class="row">
-    <div class="pull-right col-sm-2" > 
+    <div class="pull-right hidden-sm col-sm-2" >
      <ul class ="nav nav-list affix" >
       <li ng-repeat="(key,value) in semesters">  
         <a href="" ng-click="goto(key)"  >{{key}} </a> 

--- a/client/app/projects/blog/blog.html
+++ b/client/app/projects/blog/blog.html
@@ -14,17 +14,17 @@
 
   <div class="row">
     <div class="pull-right hidden-sm col-sm-2" >
-     <ul class ="nav nav-list affix" >
-      <li ng-repeat="(key,value) in semesters">  
-        <a href="" ng-click="goto(key)"  >{{key}} </a> 
+     <ul class ="nav nav-list affix">
+      <li ng-repeat="sem in listOfsem">
+        <a href="" ng-click="goto(sem)">{{sem}}</a>
       </li>
      </ul>
-  </div>
+    </div>
 
     <div class="col-md-9">
-      <div ng-repeat="(key,value) in semesters | orderBy:'-'" >
-      <h2 id = "{{key}}"> {{key}}</h2>
-        <div ng-repeat="post in value | orderBy:'-date'">
+      <div ng-repeat="sem in listOfsem">
+      <h2 id = "{{sem}}"> {{sem}}</h2>
+        <div ng-repeat="post in semesters[sem] | orderBy:'-date'">
           <div class="extra-content">
             <h2 id="title" class="col-xs-6" btf-markdown="post.title"></h2>
             <div ng-show='userInProject()'>

--- a/client/app/projects/blog/blog.html
+++ b/client/app/projects/blog/blog.html
@@ -1,6 +1,7 @@
 <div ng-include="'components/navbar/navbar.html'"></div>
 
 <div class="container">
+  <div class="row"> 
   <div class="col-xs-3">
     <h2><a href="projects/{{ project.githubUsername }}/{{ project.githubProjectName }}/profile"> {{ project.name }}</a></h2>
   </div>
@@ -9,27 +10,42 @@
     Add a post
     </button>
   </div>
-  <div class="col-sm-12">
-    <div ng-repeat="post in posts | orderBy:'-date'">
-      <div class="extra-content">
-        <h2 id="title" class="col-xs-6" btf-markdown="post.title"></h2>
-        <div ng-show='userInProject()'>
-          <div ng-show="userOwnsPost(post)"class="col-xs-6 text-right">
-          <div class="btn-group">
-            <button type="button" class='btn btn-default btn-sm' ng-click='editPost(post)'>Edit</button>
-            <button type="button" class='btn btn-default btn-sm' ng-click='savePost(post)'>Save</button>
-            <button type="button" class='btn btn-default btn-sm' ng-click='deletePost(post)'>Delete</button>
-          </div>
-          </div>
-        </div>
-        <div class="clear"></div>
-        <div  id="content" btf-markdown="post.content"></div>
-        <div class="bottom-bar">
-          <div class="bottom-bar-left">
-            <a href="users/{{ post.author._id }}/profile"> {{ post.author.name }}</a>
-          </div>
-          <div class="bottom-bar-right">
-            {{ post.date | date:'MMM dd yyyy HH:mm:ss' }}
+  </div>
+
+  <div class="row">
+    <div class="pull-right col-sm-2" > 
+     <ul class ="nav nav-list affix" >
+      <li ng-repeat="(key,value) in semesters">  
+        <a href="" ng-click="goto(key)"  >{{key}} </a> 
+      </li>
+     </ul>
+  </div>
+
+    <div class="col-md-9">
+      <div ng-repeat="(key,value) in semesters | orderBy:'-'" >
+      <h2 id = "{{key}}"> {{key}}</h2>
+        <div ng-repeat="post in value | orderBy:'-date'">
+          <div class="extra-content">
+            <h2 id="title" class="col-xs-6" btf-markdown="post.title"></h2>
+            <div ng-show='userInProject()'>
+              <div ng-show="user/dOwnsPost(post)"class="col-xs-6 text-right">
+              <div class="btn-group">
+                <button type="button" class='btn btn-default btn-sm' ng-click='editPost(post)'>Edit</button>
+                <button type="button" class='btn btn-default btn-sm' ng-click='savePost(post)'>Save</button>
+                <button type="button" class='btn btn-default btn-sm' ng-click='deletePost(post)'>Delete</button>
+              </div>
+              </div>
+            </div>
+            <div class="clear"></div>
+            <div  id="content" btf-markdown="post.content"></div>
+            <div class="bottom-bar">
+              <div class="bottom-bar-left">
+                <a href="users/{{ post.author._id }}/profile"> {{ post.author.name }}</a>
+              </div>
+              <div class="bottom-bar-right">
+                {{ post.date | date:'MMM dd yyyy HH:mm:ss' }}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/server/config/seed/posts.json
+++ b/server/config/seed/posts.json
@@ -3,24 +3,33 @@
     "_id": "5738cedfffd7ec3b75f3349c",
     "title": "My awesome post",
     "content": "This is great!",
-    "projectId": "5738cebdffd7ec3b75f3349b",
+    "projectId": "000000000000000000000030",
     "author": "5738ce217328682a75cc0a79",
-    "date": "2016-05-15T19:32:47.647Z"
+    "date": "2015-01-15T19:32:47.647Z"
   },
   {
     "_id": "5738cefdffd7ec3b75f3349d",
     "title": "Also noted this",
     "content": "_**in markdown**_",
-    "projectId": "5738cebdffd7ec3b75f3349b",
+    "projectId": "000000000000000000000030",
     "author": "5738ce217328682a75cc0a79",
-    "date": "2016-05-15T19:33:17.838Z"
+    "date": "2015-09-15T19:33:17.838Z"
   },
   {
     "_id": "5738cf0effd7ec3b75f3349e",
     "title": "*And this is fun*",
     "content": "To use **markdown**",
-    "projectId": "5738cebdffd7ec3b75f3349b",
+    "projectId": "000000000000000000000030",
     "author": "5738ce217328682a75cc0a79",
     "date": "2016-05-15T19:33:34.946Z"
+  },
+    {
+    "_id": "5738cf0effd7ec3b75f33491",
+    "title": "*And this is fun*",
+    "content": "To use **markdown**",
+    "projectId": "000000000000000000000030",
+    "author": "5738ce217328682a75cc0a79",
+    "date": "2016-12-15T19:33:34.946Z"
   }
+
 ]


### PR DESCRIPTION
1. fix by adding custom comparator.
 <del>divide posts into semesters and use a object to wrap around the semesters 
 e.g  {fall 2016:[post1, post2..], spring 2016:[ ], .....}
 pitfall: the order of the semesters can't be sorted, because there are the properties of a object.</de>l

2. fix by add hidden-sm on the sidebar
 <del> when the browser's width reduces to a certain amount (e.g a portrait ipad), the side would get under the posts. I have made use of grid </del>.

3. Angularjs might not have native support for bootstrap scrollspy? 
<del> is there a body tag? how can I edit the body tag? I need it for scrollspy. 
[bootstrap scrollspy](http://v4-alpha.getbootstrap.com/components/scrollspy/) </del> 

 #605, #368  