### PR TITLE
Fix typo on login form

### DIFF
--- a/client/app/account/login/login.html
+++ b/client/app/account/login/login.html
@@ -54,7 +54,7 @@
             <div class="panel panel-default">
                 <div class="panel-body">
                     <div class="text-center" >
-                        Need and Account?
+                        Need an Account?
                         <a tabindex="5" href="/signup">
                             Sign Up
                         </a>


### PR DESCRIPTION
The login form says "Need and Account?". This changes it to "an".