### PR TITLE
Excused Absence deletion implementation

### DIFF
--- a/server/api/excused_absence/excused_absence.controller.js
+++ b/server/api/excused_absence/excused_absence.controller.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import { handleError } from '../lib/helpers'
-import { STATUS_PENDING } from './constants'
+import { STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED } from './constants'
 import User from '../user/user.model'
 import ExcusedAbsence from './excused_absence.model'
 
@@ -85,6 +85,20 @@ exports.update = (req, res) => {
   return ExcusedAbsence.findByIdAndUpdate(req.params.id, { $set: req.body }, { new: true })
   .then((response) => {
       return res.status(200).send(response).end()
+  }).catch(next)
+}
+
+
+// TODO - document and implement
+exports.approve = (req, res) => {
+  return ExcusedAbsence.findById(req.params.id)
+  .then((excusedAbsence) => {
+      excusedAbsence.status = STATUS_APPROVED
+      excusedAbsence.reviewed_by = req.user._id
+      excusedAbsence.reviewer_note = req.body.reviewer_note
+      excusedAbsence.save().then((response) => {
+        return res.status(200).send(response).end()
+      })
   }).catch(next)
 }
 

--- a/server/api/excused_absence/excused_absence.controller.js
+++ b/server/api/excused_absence/excused_absence.controller.js
@@ -90,7 +90,6 @@ exports.update = (req, res) => {
 }
 
 
-// TODO - document and implement
 /**
 * @api {approve} /api/excused_absences/:id Approve
 * @apiName approve
@@ -132,3 +131,5 @@ exports.destroy = (req, res, next) => {
   else {
     return res.status(401).send(response).end()
   }
+}
+

--- a/server/api/excused_absence/excused_absence.controller.js
+++ b/server/api/excused_absence/excused_absence.controller.js
@@ -3,6 +3,7 @@ import { handleError } from '../lib/helpers'
 import { STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED } from './constants'
 import User from '../user/user.model'
 import ExcusedAbsence from './excused_absence.model'
+const auth = require('../../auth/auth.service')
 
 /**
 * @api {get} /api/excused_absences Index
@@ -112,9 +113,13 @@ exports.approve = (req, res) => {
 * @apiError (500) UnknownException Could not destroy ExcusedAbsence model
 */
 exports.destroy = (req, res, next) => {
-  // TODO - ensure this is only deletable by the user who created the record, or an admin
-  return ExcusedAbsence.remove({ _id: req.params.id })
-  .then((response) => {
-      return res.status(200).send(response).end()
-  }).catch(next)
-}
+    
+  if(auth.hasRole('admin') || (auth.isAuthenticated === ExcusedAbsence.findById(req.params.id).user )) {
+      return ExcusedAbsence.remove({ _id: req.params.id })
+      .then((response) => {
+          return res.status(200).send(response).end()
+      }).catch(next)}
+  
+  else {
+    return res.status(401).send(response).end()
+  }

--- a/server/api/excused_absence/excused_absence.controller.js
+++ b/server/api/excused_absence/excused_absence.controller.js
@@ -43,25 +43,6 @@ exports.admin = (req, res) => {
 }
 
 /**
-* @api {get} /api/excused_absences/:id Show
-* @apiName show
-* @apiGroup Excused Absence
-* @apiDescription Show an individual ExcusedAbsence
-* @apiPermission private
-* @apiSuccess {Model} root A single ExcusedAbsence model
-* @apiError (500) UnknownException Could not retrieve ExcusedAbsence model
-*/
-exports.show = (req, res) => {
-  return ExcusedAbsence.findById(req.params.id)
-  .then((model) => {
-    return res.json(200, model).end()
-  })
-  .catch((err) => {
-    return handleError(err)
-  })
-}
-
-/**
 * @api {post} /api/excused_absences/:id Create
 * @apiName create
 * @apiGroup Excused Absence
@@ -99,6 +80,8 @@ exports.create = (req, res) => {
 exports.update = (req, res) => {
   // TODO - isolate valid attributes depending on user role
   // Admin - update STATUS, REVIEWER_NOTE, REVIEWED_BY (automatic)
+  // TODO - perform check
+  // ExcusedAbsence.where({ _id: req.params.id, user_id: req.user._id }) is OWNED by the requesting user, IFF they're not an admin
   return ExcusedAbsence.findByIdAndUpdate(req.params.id, { $set: req.body }, { new: true })
   .then((response) => {
       return res.status(200).send(response).end()

--- a/server/api/excused_absence/excused_absence.controller.js
+++ b/server/api/excused_absence/excused_absence.controller.js
@@ -91,6 +91,15 @@ exports.update = (req, res) => {
 
 
 // TODO - document and implement
+/**
+* @api {approve} /api/excused_absences/:id Approve
+* @apiName approve
+* @apiGroup Excused Absence
+* @apiDescription Changes an ExcusedAbsence's status to STATUS_APPROVED
+* @apiPermission private
+* @apiSuccess {Model} root The approved ExcusedAbsence model
+* @apiError (500) UnknownException Could not approve ExcusedAbsence model
+*/
 exports.approve = (req, res) => {
   return ExcusedAbsence.findById(req.params.id)
   .then((excusedAbsence) => {

--- a/server/api/excused_absence/excused_absence.model.js
+++ b/server/api/excused_absence/excused_absence.model.js
@@ -4,15 +4,16 @@ import { STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED } from './constants'
 
 // QUESTION - Semester attribute?
 // QUESTION - pick date from days with SmallGroup / LargeGroup attendance only
-// TODO - `status` attribute - enumerate STATUS_PENDING / STATUS_APPROVED / STATUS_DENIED
 const ExcusedAbsenceSchema = new Schema({
-  excuse: {
+  excuse: { // Really more of 'note'
     type: String,
     required: true
   },
   status: {
     type: String,
-    required: true
+    required: true,
+    enum: [STATUS_PENDING, STATUS_APPROVED, STATUS_DENIED]
+    // TODO - `status` attribute - enumerate STATUS_PENDING / STATUS_APPROVED / STATUS_DENIED
   },
   user: {
     type : Schema.Types.ObjectId,

--- a/server/api/excused_absence/index.js
+++ b/server/api/excused_absence/index.js
@@ -25,20 +25,4 @@ router.delete('/:id', auth.isAuthenticated(), controller.destroy)
 module.exports = router
 
 
-// User
-// [X] List their ExcusedAbsence (show all pending / approved / denied)
-// [ ] Create ExcusedAbsence (Request - pending approval)
-// [ ] Update ExcusedAbsence (Change note, date, date-range)
-// [ ] Delete ExcusedAbsence (It's not needed anymore)
 
-// [X] Admin
-// [ ] List ALL ExcusedAbsences
-// [ ] Update ExcusedAbsence (something changed - note or date ONLY)
-// [ ] Delete ExcusedAbsence (It's not needed anymore)
-
-// [ ] Approve Individual ExcusedAbsence (Approve + leave note)
-// [ ] Deny Individual ExcusedAbsence (Deny + leave note)
-
-// [ ] Common to both
-// [ ] Update
-// [ ] Delete

--- a/server/api/excused_absence/index.js
+++ b/server/api/excused_absence/index.js
@@ -3,11 +3,42 @@ const controller = require('./excused_absence.controller')
 const auth = require('../../auth/auth.service')
 const router = express.Router()
 
+// GET /api/excused_absences
 router.get('/', auth.isAuthenticated(), controller.index)
+
+// GET /api/excused_absences/admin
 router.get('/admin', auth.hasRole('admin'), controller.admin)
-router.get('/:id', auth.isAuthenticated(), controller.show)
+
+// POST /api/excused_absences
 router.post('/', auth.isAuthenticated(), controller.create)
-router.put('/:id', auth.hasRole('admin'), controller.update)
+
+// PUT /api/excused_absences/:id
+router.put('/:id', auth.isAuthenticated(), controller.update)
+
+// Admin-only PUTs
+// PUT /api/excused_absences/:id
+router.put('/:id/approve', auth.hasRole('admin'), controller.update)
+router.put('/:id/deny', auth.hasRole('admin'), controller.update)
+
 router.delete('/:id', auth.isAuthenticated(), controller.destroy)
 
 module.exports = router
+
+
+// User
+// [X] List their ExcusedAbsence (show all pending / approved / denied)
+// [ ] Create ExcusedAbsence (Request - pending approval)
+// [ ] Update ExcusedAbsence (Change note, date, date-range)
+// [ ] Delete ExcusedAbsence (It's not needed anymore)
+
+// [X] Admin
+// [ ] List ALL ExcusedAbsences
+// [ ] Update ExcusedAbsence (something changed - note or date ONLY)
+// [ ] Delete ExcusedAbsence (It's not needed anymore)
+
+// [ ] Approve Individual ExcusedAbsence (Approve + leave note)
+// [ ] Deny Individual ExcusedAbsence (Deny + leave note)
+
+// [ ] Common to both
+// [ ] Update
+// [ ] Delete


### PR DESCRIPTION
in the destroy function, I added checks to verify that if you're not an admin, you can only destroy your own excused absences. Admins can still delete any excused absence

I also documented the approve function